### PR TITLE
Manually update vendor table

### DIFF
--- a/VENDORS.md
+++ b/VENDORS.md
@@ -6,6 +6,7 @@ Vendors are listed for their in stock purchases, not GBs.
   - [North America](#north-america)
     - [USA](#usa)
     - [Canada](#canada)
+    - [Mexico](#mexico)
   - [Europe](#europe)
     - [Continental Europe](#continental-europe)
     - [UK](#brexit-exclusion-zone)
@@ -24,19 +25,18 @@ If you notice any mistakes, or would like to contribute, feel free to **make** a
 | [1upKeyboards](https://1upkeyboards.com)                     | [x]      | [x]  | [x]   | [x]    | [x]     | [x]       | New York, NY               |
 | [3DKeebs](https://3dkeebs.com)                               | [x]      | [x]  | [x]   |        |         |           | Dallas, TX                 |
 | [415keys](https://415keys.com)                               | [x]      | [x]  | [x]   |        |         |           | Richmond, NC               |
-| [Alphakeys (US)](https://alphakeys.com/)                     | [x]      |      |       |        |         |           | ?                          |
-| [Asceny](https://asceny.com/)                                |          |      |       | [x]    |         |           | ?                          |
-| [BoardSource](https://boardsource.xyz/)<sup>1</sup>          |          |      |       |        |         | [x]       | ?                          |
+| [Alphakeys (US)](https://alphakeys.com/)                     | [x]      | [x]  | [x]   |        |         |           | ?                          |
+| [Asceny](https://asceny.com/)                                |          |      | [x]   | [x]    |         | [x]       | ?                          |
+| [BoardSource](https://boardsource.xyz/)<sup>1</sup>          | [x]      | [x]  | [x]   |        | [x]     | [x]       | ?                          |
 | [Cable Craze](https://cablecraze.net/)                       |          |      |       | [x]    |         |           | ?                          |
 | [Cannon Keys](https://cannonkeys.com/)                       | [x]      | [x]  | [x]   | [x]    | [x]     | [x]       | Rhode Island               |
-| [ClueBoard](https://clueboard.co/)                           | [x]      | [x]  | [x]   |        | [x]     | [x]       | ?                          |
 | [Checkerboards](https://www.checkerboards.xyz)<sup>1</sup>   | [x]      |      | [x]   |        |         | [x]       | Waco, TX
 | [Coaxius](https://coaxius.com/)                              |          |      |       | [x]    |         |           | California                 |
 | [Cookie Cables](https://cookiecables.com/)                   |          |      |       | [x]    |         |           | ?                          |
 | [Cruz Ctrl](https://cruzctrl.gg/)                            |          |      |       | [x]    |         |           | Bay Area, CA               |
 | [Cup Cables](https://cupcables.com/)                         |          |      |       | [x]    |         |           | Oakland, CA                |
-| [DangKeebs](https://dangkeebs.com/)                          | [x]      | [x]  |       |        |         |           | Boston, MA                 |
-| [Digital Carpentry](https://digital-carpentry.com/)          |          | [x]  |       |        |         |           | Kentucky                   |
+| [DangKeebs](https://dangkeebs.com/)                          | [x]      | [x]  | [x]   |        | [x]     |           | Las Vegas, NV              |
+| [Digital Carpentry](https://digital-carpentry.com/)          |          |      |       |        |         |           | Kentucky                   |
 | [Divinikey](https://divinikey.com/)                          | [x]      | [x]  | [x]   | [x]    | [x]     | [x]       | Los Angeles, CA            |
 | [Donut Cables](https://donutcables.com/)                     |          |      |       | [x]    |         |           | ?                          |
 | [Dream Cables](https://dream-cables.com/)                    |          |      |       | [x]    |         |           | Utah                       |
@@ -44,47 +44,45 @@ If you notice any mistakes, or would like to contribute, feel free to **make** a
 | [Endgame Keys](https://endgamekeys.com/)                     |          | [x]  | [x]   |        |         |           | Indiana                    |
 | [FlashQuark](https://flashquark.com/)                        | [x]      | [x]  | [x]   |        | [x]     | [x]       | New York                   |
 | [Flex Cables](https://flexcablesstore.com/)                  |          |      |       | [x]    |         |           | ?                          |
-| [IcedKeys](https://icedkeys.com/)                            | [x]      |      |       |        |         |           | Austin, TX                 |
 | [Kebo](https://kebo.store/)                                  | [x]      | [x]  | [x]   |        |         |           | San Gabriel, CA            |
 | [Keebio](https://keeb.io)<sup>1</sup>                        |          |      | [x]   |        |         | [x]       | Durham, NC                 |
-| [KeebsForAll](https://keebsforall.com/)                      | [x]      | [x]  | [x]   | [x]    | [x]     |           | Los Angeles, CA            |
+| [KeebsForAll](https://keebsforall.com/)                      | [x]      | [x]  | [x]   |        | [x]     |           | Los Angeles, CA            |
 | [KeyboardLube](https://keyboardlube.com/)                    |          | [x]  |       |        |         |           | Washington                 |
 | [KeyHive](https://keyhive.xyz/shop)<sup>1</sup>              |          |      | [x]   |        |         | [x]       | Utah                       |
 | [Kimdi Keys](https://kimdi-keys.com/)                        | [x]      | [x]  | [x]   |        |         |           | Upstate New York           |
-| [Kinetic Labs](https://kineticlabs.store/)                   | [x]      | [x]  |       |        | [x]     |           | New Jersey                 |
+| [Kinetic Labs](https://kineticlabs.store/)                   | [x]      | [x]  | [x]   |        | [x]     |           | New Jersey                 |
 | [Kono](https://kono.store/)                                  | [x]      | [x]  | [x]   | [x]    | [x]     | [x]       | intentionally confusing    |
 | [Kraken Keyboards](https://krakenkeyboards.com/)             |          |      |       | [x]    | [x]     | [x]       | California (Southern)      |
 | [Little Keyboards](https://littlekeyboards.com/)<sup>1</sup> | [x]      | [x]  | [x]   |        | [x]     | [x]       | North Carolina             |
-| [MaxKeyboard](https://maxkeyboard.com/)                      |          |      |       |        |         | [x]       | California (Northern)      |
-| [MechanicalKeyboards](https://mechanicalkeyboards.com/)      |          |      |       |        | [x]     | [x]       | Tennessee                  |
+| [MaxKeyboard](https://maxkeyboard.com/)                      | [x]      |      |       |        | [x]     | [x]       | California (Northern)      |
+| [MechanicalKeyboards](https://mechanicalkeyboards.com/)      | [x]      |      | [x]   |        | [x]     | [x]       | Tennessee                  |
 | [MechCables](https://mechcables.com/)                        |          |      |       | [x]    |         |           | Virginia                   |
-| [Mechwild](https://mechwild.com/)<sup>1</sup>                | [x]      |      |       |        |         | [x]       | Ohio                       |
+| [Mechwild](https://mechwild.com/)<sup>1</sup>                | [x]      |      | [x]   |        |         | [x]       | Ohio                       |
 | [Mekibo (TX Keyboards)](https://mekibo.com/)                 | [x]      | [x]  | [x]   |        | [x]     | [x]       | Garden Grove, CA           |
 | [Mimic Cables](https://mimic-cables.com/)                    |          |      |       | [x]    |         |           | ?                          |
 | [MKUltra](https://mkultra.click/)                            | [x]      |      |       | [x]    | [x]     | [x]       | Angels Camp, CA            |
 | [NovelKeys_](https://novelkeys.xyz/)                         | [x]      | [x]  | [x]   |        | [x]     | [x]       | Morgantown, WV             |
-| [OriginativeCo](https://originativeco.com/)                  |          |      |       |        | [x]     |           | Irvine, CA                 |
+| [OriginativeCo](https://originativeco.com/)                  | [x]      |      | [x]   |        | [x]     | [x]       | Irvine, CA                 |
 | [Paramountkeeb](https://paramountkeeb.com/)                  | [x]      | [x]  | [x]   |        |         | [x]       | ChickenMan's Basement, CA  |
 | [Prevail KeyCo](https://prevailkeyco.com/)                   | [x]      | [x]  | [x]   |        |         |           | Florida                    |
 | [PrimeKB](https://primekb.com/)                              | [x]      | [x]  | [x]   |        | [x]     | [x]       | Aledo, TX                  |
-| [RGBKB](https://rgbkb.net/)                                  | [x]      | [x]  | [x]   | [x]    | [x]     | [x]       | Connecticut                |
-| [Ringer Keys](https://ringerkeys.com/)                       | [x]      | [x]  | [x]   |        | [x]     | [x]       | Greater Boston, MA         |
-| [Rockets Cables](https://rocketscables.com/)                 |          |      |       | [x]    |         |           | ?                          |
-| [Space Cables](https://spaceholdings.net/)                   |          |      |       | [x]    |         |           | Austin, TX                 |
+| [RGBKB](https://rgbkb.net/)                                  | [x]      |      |       |        | [x]     | [x]       | Connecticut                |
+| [Ringer Keys](https://ringerkeys.com/)                       | [x]      | [x]  | [x]   |        |         | [x]       | Greater Boston, MA         |
+| [Space Cables](https://spaceholdings.net/)                   |          | [x]  | [x]   | [x]    | [x]     |           | Austin, TX                 |
 | [Spaztik Cables](https://spaztikcables.com/)                 |          |      |       | [x]    |         |           | Utah                       |
 | [Switch Couture](https://switchcouture.com/)                 |          |      |       |        |         | [x]       | Florida                    |
 | [Switchmod](https://switchmod.net/)                          |          | [x]  |       |        |         |           | Minnesota -- Massachusetts |
-| [SwitchTop](https://switchtop.com/)                          | [x]      |      | [x]   |        |         | [x]       | ?                          |
+| [SwitchTop](https://switchtop.com/)                          | [x]      |      | [x]   |        | [x]     |           | Texas                      |
 | [Teal Technik](https://tealtechnik.com/)                     | [x]      | [x]  | [x]   |        |         |           | ?                          |
 | [Tez Cables](https://tezcables.com/)                         |          |      |       | [x]    |         |           | ?                          |
-| [TheKey.Company](https://thekey.company/)                    | [x]      | [x]  | [x]   | [x]    | [x]     | [x]       | Michigan                   |
-| [Thockeys](https://thockeys.com/)                            | [x]      |      | [x]   | [x]    | [x]     |           | Westminster, MA            |
-| [Thockpop](https://thockpop.com/)                            | [x]      | [x]  | [x]   | [x]    | [x]     |           | Houston, TX                |
+| [TheKey.Company](https://thekey.company/)                    | [x]      | [x]  | [x]   |        | [x]     | [x]       | Michigan                   |
+| [Thockeys](https://thockeys.com/)                            | [x]      | [x]  | [x]   |        | [x]     |           | Westminster, MA            |
+| [Thockpop](https://thockpop.com/)                            | [x]      | [x]  | [x]   |        | [x]     |           | Houston, TX                |
 | [Typr Tools](https://typr.tools/)                            | [x]      | [x]  | [x]   |        |         |           | California (Northern)      |
 | [Upgrade Keyboards](https://upgradekeyboards.com/)           | [x]      | [x]  | [x]   | [x]    | [x]     | [x]       | Houston, TX                |
-| [WASD Keyboards](https://wasdkeyboards.com/)                 |          |      |       |        | [x]     | [x]       | California                 |
+| [WASD Keyboards](https://wasdkeyboards.com/)                 | [x]      |      |       |        | [x]     | [x]       | California                 |
 | [Worldspawn](https://etsy.com/shop/WorldspawnsKeebs)<sup>1</sup>|       |      |       |        |         | [x]       | Austin, TX                 |
-| [Winnja](https://winnja.com/)                                |          |      |       | [x]    |         |           | Texas                      |
+| [Winnja](https://winnja.com/)                                |          |      | [x]   | [x]    |         |           | Texas                      |
 | [Zap Cables](https://zapcables.com/)                         |          |      |       | [x]    |         |           | Wisconsin                  |
 
 <sup>1</sup>: Through-hole keyboard specialty
@@ -93,18 +91,17 @@ If you notice any mistakes, or would like to contribute, feel free to **make** a
 
 | Vendor                                                       | Switches | Lube | Stabs | Cables | Keycaps | Keyboards | Location                   |
 | ------------------------------------------------------------ | -------- | ---- | ----- | ------ | ------- | --------- | -------------------------- |
-| [AlphaKeys](https://alphakeys.ca/)                           | [x]      | [x]  |       |        |         |           | Toronto, ON                |
+| [AlphaKeys](https://alphakeys.ca/)                           | [x]      | [x]  | [x]   |        |         |           | Toronto, ON                |
 | [Apex Keyboards](https://apexkeyboards.ca/)                  | [x]      | [x]  | [x]   |        |         |           | Toronto, ON                |
-| [Ashkeebs](https://ashkeebs.com/)                            | [x]      |      |       |        |         |           | Victoria, BC               |
-| [Badger Cables](https://badgercables.com/)                   |          |      |       | [x]    |         |           | Victoria, BC               |
+| [Ashkeebs](https://ashkeebs.com/)                            | [x]      | [x]  | [x]   |        |         |           | Victoria, BC               |
 | [DeskHero](https://deskhero.ca/)                             | [x]      |      |       |        | [x]     | [x]       | Winnipeg, MB               |
 | [MechLand](https://mech.land)                                | [x]      | [x]  | [x]   |        |         |           | Scarborough, ON            |
-| [MinoKeys](https://minokeys.com/)                            | [x]      | [x]  | [x]   | [x]    |         |           | Ontario                    |
-| [Malvix](https://store.malvix.com/)                          | [x]      | [x]  | [x]   |        |         |           | Vancouver, BC              |
-| [Noodle Cords](https://noodlecords.ca/)                      |          |      |       |        | [x]     |           | Canada                     |
-| [OmegaKeys](https://omegakeys.ca/)                           | [x]      | [x]  | [x]   |        |         |           | Port Moody, BC             |
+| [MinoKeys](https://minokeys.com/)                            | [x]      | [x]  | [x]   | [x]    |         | [x]       | Ontario                    |
+| [Malvix](https://store.malvix.com/)                          | [x]      | [x]  | [x]   |        |         | [x]       | Vancouver, BC              |
+| [Noodle Cords](https://noodlecords.ca/)                      |          |      |       | [x]    |         |           | Canada                     |
+| [OmegaKeys](https://omegakeys.ca/)                           | [x]      | [x]  | [x]   |        |         | [x]       | Port Moody, BC             |
 | [OneOfZero](https://oneofzero.net)                           | [x]      |      |       |        | [x]     | [x]       | Canada                     |
-| [RNDKBD](https://rndkbd.com/)                                | [x]      | [x]  | [x]   |        |         |           | Calgary, AB                |
+| [RNDKBD](https://rndkbd.com/)                                | [x]      | [x]  | [x]   |        |         | [x]       | Calgary, AB                |
 | [tokeebs](https://tokeebs.ca)                                | [x]      | [x]  | [x]   |        |         |           | Toronto, ON                |
 | [Vintkeys](https://vintkeys.ca/)                             | [x]      | [x]  |       |        |         | [x]       | Canada                     |
 | [ZealPC](https://zealpc.net/)                                | [x]      | [x]  | [x]   |        |         | [x]       | Richmond, BC               |
@@ -115,7 +112,7 @@ If you notice any mistakes, or would like to contribute, feel free to **make** a
 
 | Vendor                                                       | Switches | Lube | Stabs | Cables | Keycaps | Keyboards | Location                   |
 | ------------------------------------------------------------ | -------- | ---- | ----- | ------ | ------- | --------- | -------------------------- |
-| [Rheset](https://rheset.mx/)                                 | [x]      | [x]  | [x]   |        | [x]     | [x]       | Mexico                     |
+| [Rheset](https://rheset.mx/)                                 | [x]      | [x]  | [x]   |        | GB      |           | Mexico                     |
 
 
 ## Europe
@@ -125,20 +122,21 @@ If you notice any mistakes, or would like to contribute, feel free to **make** a
 | Vendor                                             | Switches | Lube | Stabs | Cables | Keycaps | Keyboards | Location    |
 | -------------------------------------------------- | -------- | ---- | ----- | ------ | ------- | --------- | ----------- |
 | [42Keebs](https://42keebs.eu)<sup>1</sup>          | [x]      | [x]  | [x]   |        |         | [x]       | Czechia     |
-| [CandyKeys](https://candykeys.com/)                | [x]      | [x]  | [x]   | [x]    | [x]     | [x]       | Germany     |
+| [CandyKeys](https://candykeys.com/)                | [x]      | [x]  | [x]   |        | [x]     | [x]       | Germany     |
 | [Clark Cable](https://clarkkable.com/)             |          |      |       | [x]    |         |           | Germany     |
 | [Eloquent Clicks](https://www.eloquentclicks.com/) | [x]      | [x]  | [x]   | [x]    | [x]     | [x]       | Spain       |
 | [KBnordic](https://kbnordic.eu)                    | [x]      | [x]  | [x]   |        | [x]     | PCB/Plate | Sweden      |
 | [Keeb.Studio](https://keeb.studio/)                |          |      |       | [x]    |         |           | Belgium     |
+| [Keebstuff](https://keebstuff.com/)                |          |      |       | [x]    |         |           | Germany     |
 | [Keebwerk](https://keebwerk.com/)                  | [x]      |      |       |        |         | [x]       | Germany     |
-| [Keyb.no](https://keyb.no/)                        | [x]      | [x]  | [x]   | [x]    | [x]     | [x]       | Norway      |
-| [KeyCapsss](https://keycapsss.com/)                | [x]      | [x]  | [x]   | [x]    | [x]     | [x]       | Germany     |
+| [Keyb.no](https://keyb.no/)                        | [x]      | [x]  | [x]   |        | [x]     | [x]       | Norway      |
+| [KeyCapsss](https://keycapsss.com/)                | [x]      | [x]  | [x]   |        | [x]     | [x]       | Germany     |
 | [Keygem](https://keygem.store/)                    | [x]      | [x]  | [x]   | [x]    | [x]     | [x]       | Germany     |
-| [Kris Cables](https://kriscables.com/)             |          |      |       | [x]    |         |           | Portugal    |
+| [Kriscables](https://kriscables.com/)<sup>1</sup>  | [x]      |      |       | [x]    | [x]     | [x]       | Portugal    |
 | [Mechanisk](https://mekanisk.com/)                 | [x]      |      | [x]   |        |         | [x]       | Norway      |
-| [MyKeyboard](https://mykeyboard.eu/)               | [x]      | [x]  | [x]   | [x]    | [x]     | [x]       | Belgium     |
-| [Oblotsky](https://oblotzky.industries/)           | [x]      |      |       |        | [x]     |           | Germany     |
-| [SplitKB](https://splitkb.com/)<sup>1</sup>        | [x]      | [x]  | [x]   | [x]    | [x]     | [x]       | Netherlands |
+| [MyKeyboard](https://mykeyboard.eu/)               | [x]      | [x]  | [x]   |        | [x]     | [x]       | Belgium     |
+| [Oblotsky](https://oblotzky.industries/)           | [x]      |      |       |        | [x]     | [x]       | Germany     |
+| [SplitKB](https://splitkb.com/)<sup>1</sup>        | [x]      |      | [x]   |        | [x]     | [x]       | Netherlands |
 
 <sup>1</sup>: Through-hole keyboard specialty
 
@@ -148,13 +146,13 @@ If you notice any mistakes, or would like to contribute, feel free to **make** a
 | -------------------------------------------------- | -------- | ---- | ----- | ------ | ------- | --------- | ----------- |
 | [Cool Cables](https://coolcable.co.uk/)            |          |      |       | [x]    |         |           | UK          |
 | [KeebCats](https://keebcats.co.uk/)                | [x]      | [x]  | [x]   |        |         |           | UK          |
-| [Keycrox](https://www.keycrox.co.uk/)              | [x]      | [x]  | [x]   |        |         |           | UK          |
-| [MechBoards](https://mechboards.co.uk/)            | [x]      | [x]  | [x]   | [x]    | [x]     | [x]       | UK          |
-| [MechBox](https://mechbox.co.uk/)                  | [x]      |      |       | [x]    | [x]     |           | UK          |
+| [Keycrox](https://www.keycrox.co.uk/)              | [x]      | [x]  | [x]   | [x]    | [x]     | [x]       | UK          |
+| [Mechboards](https://mechboards.co.uk/)<sup>1</sup>| [x]      | [x]  | [x]   | [x]    | [x]     | [x]       | UK          |
+| [MechBox](https://mechbox.co.uk/)                  | [x]      |      |       |        | [x]     |           | UK          |
 | [OpticBoards](https://www.opticboards.com/)        | [x]      | [x]  | [x]   |        |         |           | UK          |
 | [Pexon](https://pexonpcs.co.uk/)                   |          |      |       | [x]    |         |           | UK          |
-| [Prototypist](https://prototypist.net/)            | [x]      | [x]  | [x]   |        | [x]     |           | UK          |
-| [TheKeyboardCo](https://www.keyboardco.com/)       | [x]      |      | [x]   | [x]    |         | [x]       | UK          |
+| [Prototypist](https://prototypist.net/)            | [x]      | [x]  | [x]   |        | [x]     | [x]       | UK          |
+| [TheKeyboardCo](https://www.keyboardco.com/)       | [x]      |      | [x]   | [x]    | [x]     | [x]       | UK          |
 | [Tokas Cables](https://shop.tokas.co.uk/)          |          |      |       | [x]    |         |           | UK          |
 | [UK Keycaps](http://www.ukkeycaps.co.uk/)          | [x]      |      |       |        | [x]     | [x]       | UK          |
 
@@ -162,35 +160,34 @@ If you notice any mistakes, or would like to contribute, feel free to **make** a
 
 | Vendor                                                         | Switches | Lube | Stabs | Cables | Keycaps | Keyboards | Location     |
 | -------------------------------------------------------------- | -------- | ---- | ----- | ------ | ------- | --------- | ------------ |
-| [BeeKeeb](https://shop.beekeeb.com/)<sup>1</sup>               | [x]      |      |       | [x]    | [x]     | [x]       | China (PRC)  |
+| [BeeKeeb](https://shop.beekeeb.com/)<sup>1</sup>               | [x]      |      |       |        | [x]     | [x]       | China (PRC)  |
 | [DoyuStudios](https://shopkey.doyustudio.com/)                 | [x]      |      | [x]   |        | [x]     |           | Taiwan (ROC) |
 | [ErgoMech](https://ergomech.store/shop)<sup>1</sup>            |          |      |       |        |         | [x]       | Vietnam      |
 | [GenesisPC](https://www.genesispc.in/)                         | [x]      | [x]  | [x]   |        | [x]     | [x]       | India        |
 | [idobao](https://www.idobao.net/)                              | [x]      |      | [x]   | [x]    | [x]     | [x]       | China (PRC)  |
 | [IlumKB](https://ilumkb.com/)                                  | [x]      | [x]  | [x]   |        | [x]     | [x]       | Singapore    |
-| [Infinity Key](https://infinitykey.zone/)                      |          |      |       |        |         |           | Vietnam      |
-| [KBD4U](http://kbd4u.com/)                                     |          |      |       |        |         |           | South Korea  |
+| [KBD4U](http://kbd4u.com/)                                     |          |      |       |        |         | [x]       | South Korea  |
 | [KBDfans](https://kbdfans.com/)                                | [x]      |      | [x]   | [x]    | [x]     | [x]       | China (PRC)  |
 | [Kelowna](https://sloer.world.taobao.com/)                     | [x]      | [x]  | [x]   | [x]    | [x]     |           | China (PRC)  |
-| [Keys.my](https://keys.my/)                                    | [x]      | [x]  | [x]   |        | [x]     |           | Malaysia     |
-| [KPRepublic](https://kprepublic.com/)                          | [x]      | [x]  | [x]   | [x]    | [x]     | [x]       | China (PRC)  |
-| [KwertieKeys](https://www.kwertiekeys.com/)                    | [x]      |      |       | [x]    | [x]     | [x]       | Singapore    |
-| [LetsGetIt](https://letsgetit.io/)                             | [x]      | [x]  | [x]   |        |         |           | South Korea  |
-| [Mecha](https://mecha.store/)                                  | [x]      | [x]  | [x]   |        | [x]     | [x]       | Singapore    |
+| [Keys.my](https://keys.my/)                                    | [x]      | [x]  | [x]   |        |         |           | Malaysia     |
+| [KPRepublic](https://kprepublic.com/)                          | [x]      |      | [x]   | [x]    | [x]     | [x]       | China (PRC)  |
+| [KwertieKeys](https://www.kwertiekeys.com/)                    | [x]      |      |       | [x]    | [x]     |           | Singapore    |
+| [LetsGetIt](https://letsgetit.io/)                             |          | [x]  | [x]   |        |         |           | South Korea  |
+| [Mecha](https://mecha.store/)                                  | [x]      | [x]  | [x]   | [x]    | [x]     | [x]       | Singapore    |
 | [MechanicalKeyboards](https://www.mechanicalkeyboards.co.id/)  | [x]      | [x]  | [x]   | [x]    | [x]     | [x]       | Indonesia    |
 | [MecKey Alpha](https://meckeyalpha.com/)                       | [x]      | [x]  | [x]   |        | [x]     | [x]       | China (PRC)  |
-| [Meckeys](https://www.meckeys.com/)                            | [x]      |      | [x]   | [x]    | [x]     | [x]       | India        |
+| [Meckeys](https://www.meckeys.com/)                            | [x]      |      |       | [x]    | [x]     | [x]       | India        |
 | [Monokei](https://store.monokei.co)                            |          | [x]  |       |        |         |           | Singapore    |
 | [MelGeek](https://www.melgeek.com/)                            | [x]      |      | [x]   | [x]    | [x]     | [x]       | China (PRC)  |
-| [Monstargears](https://www.monstargears.com/)                  | [x]      |      | [x]   | [x]    | [x]     | [x]       | South Korea  |
-| [PantheonKeys](https://pantheonkeys.com/)                      | [x]      | [x]  | [x]   | [x]    | [x]     | [x]       | Singapore    |
-| [Qwertyqop](https://qwertyqop.com/)                            | [x]      |      | [x]   |        | [x]     |           | Singapore    |
+| [Monstargears](https://www.monstargears.com/)                  | [x]      | [x]  | [x]   | [x]    | [x]     | [x]       | South Korea  |
+| [PantheonKeys](https://pantheonkeys.com/)                      | [x]      | [x]  | [x]   | [x]    | [x]     |           | Singapore    |
+| [Qwertyqop](https://qwertyqop.com/)                            | [x]      | [x]  | [x]   | [x]    | [x]     | [x]       | Singapore    |
 | [Rectangles.store](https://rectangles.store/)                  | [x]      | [x]  | [x]   |        |         | [x]       | India        |
-| [StacksKB](https://stackskb.com/)                              | [x]      | [x]  | [x]   | [x]    | [x]     | [x]       | India        |
+| [StacksKB](https://stackskb.com/)                              | [x]      | [x]  | [x]   |        | [x]     | [x]       | India        |
 | [SwagKeys](https://swagkeys.com/)                              | [x]      | [x]  | [x]   |        | [x]     |           | South Korea  |
 | [Thic Thock](https://thicthock.com/)                           | [x]      |      | [x]   |        |         |           | China (PRC)  |
 | [Westech](https://uwestech.com.sg/product/keyboard-lubricant/) |          | [x]  |       |        |         |           | Singapore    |
-| [YMDK](https://ymdkey.com/)                                    | [x]      | [x]  | [x]   | [x]    | [x]     | [x]       | China (PRC)  |
+| [YMDK](https://ymdkey.com/)                                    | [x]      |      | [x]   | [x]    | [x]     | [x]       | China (PRC)  |
 | [YushaKobo](https://yushakobo.jp/)<sup>1</sup>                 | [x]      | [x]  | [x]   | [x]    | [x]     | [x]       | Japan        |
 
 <sup>1</sup>: Through-hole keyboard specialty
@@ -199,16 +196,16 @@ If you notice any mistakes, or would like to contribute, feel free to **make** a
 
 | Vendor                                               | Switches | Lube | Stabs | Cables | Keycaps | Keyboards | Location    |
 | ---------------------------------------------------- | -------- | ---- | ----- | ------ | ------- | --------- | ------------|
-| [AllCaps](https://allcaps.store/)                    | [x]      | [x]  | [x]   |        | GB?     |           | Australia   |
+| [AllCaps](https://allcaps.store/)                    | [x]      | [x]  | [x]   |        | GB      |           | Australia   |
 | [Click Clack Cables](https://clickclackcables.com/)  |          |      |       | [x]    |         |           | Australia   |
 | [CustomKBD](https://customkbd.com/)<sup>1</sup>      | [x]      | [x]  | [x]   |        | [x]     | [x]       | Australia   |
-| [DailyClack](https://dailyclack.com/)                | [x]      | [x]  | [x]   |        | [x]     |           | Australia   |
-| [keebd](https://keebd.com/)<sup>1</sup>              | [x]      |      | [x]   |        | [x]     | [x]       | Australia   |
+| [DailyClack](https://dailyclack.com/)                | [x]      | [x]  | [x]   |        | [x]     | [x]       | Australia   |
+| [keebd](https://keebd.com/)<sup>1</sup>              | [x]      |      | [x]   | [x]    | [x]     | [x]       | Australia   |
 | [keebord](https://keebord.nz/)                       | [x]      |      | [x]   | [x]    | [x]     | [x]       | New Zealand |
-| [Keyboard Treehouse](https://keyboardtreehouse.com/) | [x]      |      |       |        |         |           | Australia   |
-| [Keyboard Treehouse (AUS)](https://treehousehobbies.com)<sup>2</sup> | | |     |        |         | [x]       | Australia   |
-| [Mech Stock](https://mechstock.com.au/)              | [x]      | [x]  | [x]   |        |         |           | Australia   | 
-| [Mountain Keyboards](https://mountainkeyboards.com/) | [x]      |      | [x]   | [x]    | [x]     |           | Australia   |
+| [Keyboard Treehouse](https://keyboardtreehouse.com/) |          |      |       |        | [x]     | [x]       | Australia   |
+| [Keyboard Treehouse (AUS)](https://treehousehobbies.com)<sup>2</sup> | | |     |        | [x]     | [x]       | Australia   |
+| [Mech Stock](https://mechstock.com.au/)              | [x]      | [x]  |       |        |         | [x]       | Australia   | 
+| [Mountain Keyboards](https://mountainkeyboards.com/) | [x]      | [x]  | [x]   | [x]    | [x]     | [x]       | Australia   |
 | [PC Case Gear](https://www.pccasegear.com/)          | [x]      |      |       | [x]    | [x]     | [x]       | Australia   |
 | [Switchkeys](https://www.switchkeys.com.au/)         | [x]      | [x]  | [x]   |        | [x]     | [x]       | Australia   |
 | [Escape Keyboards](https://esckeyboard.com/)         | [x]      | [x]  |       |        | [x]     |           | Australia   |
@@ -220,4 +217,4 @@ If you notice any mistakes, or would like to contribute, feel free to **make** a
 
 | Vendor                                   | Switches | Lube | Stabs | Cables | Keycaps | Keyboards | Location |
 | ---------------------------------------- | -------- | ---- | ----- | ------ | ------- | --------- | -------- |
-| [RationalKeys](https://rationalkeys.com) | [x]      | [x]  | [x]   |        | [x]     | [x]       | Turkey   |
+| [RationalKeys](https://rationalkeys.com) | [x]      |      | [x]   |        | [x]     | [x]       | Turkey   |

--- a/VENDORS.md
+++ b/VENDORS.md
@@ -64,6 +64,7 @@ If you notice any mistakes, or would like to contribute, feel free to **make** a
 | [NovelKeys_](https://novelkeys.xyz/)                         | [x]      | [x]  | [x]   |        | [x]     | [x]       | Morgantown, WV             |
 | [OriginativeCo](https://originativeco.com/)                  | [x]      |      | [x]   |        | [x]     | [x]       | Irvine, CA                 |
 | [Paramountkeeb](https://paramountkeeb.com/)                  | [x]      | [x]  | [x]   |        |         | [x]       | ChickenMan's Basement, CA  |
+| [Pkkeyboards](https://pkkeyboards.com/)                      | [x]      | [x]  | [x]   | [x]    | [x]     | [x]       | Southern California        |
 | [Prevail KeyCo](https://prevailkeyco.com/)                   | [x]      | [x]  | [x]   |        |         |           | Florida                    |
 | [PrimeKB](https://primekb.com/)                              | [x]      | [x]  | [x]   |        | [x]     | [x]       | Aledo, TX                  |
 | [RGBKB](https://rgbkb.net/)                                  | [x]      |      |       |        | [x]     | [x]       | Connecticut                |

--- a/VENDORS.md
+++ b/VENDORS.md
@@ -81,7 +81,7 @@ If you notice any mistakes, or would like to contribute, feel free to **make** a
 | [Thockpop](https://thockpop.com/)                            | [x]      | [x]  | [x]   |        | [x]     |           | Houston, TX                |
 | [Typr Tools](https://typr.tools/)                            | [x]      | [x]  | [x]   |        |         |           | California (Northern)      |
 | [Upgrade Keyboards](https://upgradekeyboards.com/)           | [x]      | [x]  | [x]   | [x]    | [x]     | [x]       | Houston, TX                |
-| [WASD Keyboards](https://wasdkeyboards.com/)                 | [x]      |      |       |        | [x]     | [x]       | California                 |
+| [WASD Keyboards](https://wasdkeyboards.com/)                 | [x]      |      |       | [x]    | [x]     | [x]       | California                 |
 | [Worldspawn](https://etsy.com/shop/WorldspawnsKeebs)<sup>1</sup>|       |      |       |        |         | [x]       | Austin, TX                 |
 | [Winnja](https://winnja.com/)                                |          |      | [x]   | [x]    |         |           | Texas                      |
 | [Zap Cables](https://zapcables.com/)                         |          |      |       | [x]    |         |           | Wisconsin                  |


### PR DESCRIPTION
Edits to many vendor's available products in the table. A couple changes to location and vendor naming. Removed dead vendors: ClueBoard, IcedKeys, Rockets Cables, Badger Cables (dormant for almost a year), Infinity Key. Add Keebstuff. Add Kriscables and Mechboards as through-hole. Add Mexico to table of contents.